### PR TITLE
Implementing an option to continue processing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Embulk parser plugin for apache log (common, combined)
 ## Configuration
 
 - **format**: log format(common,combined) (string, default: combined)
+- **stop_on_invalid_record**: ignore invalid log entries (true, false) (boolean, default: true)
 
 ## Example
 
@@ -19,6 +20,7 @@ in:
   parser:
     type: apache-log
     format: common
+    stop_on_invalid_record: true
 ```
 
 ```


### PR DESCRIPTION
We often have apache access logs that contain unparsable or badly
formatted data.  This patch enables a new config option to continue on
processing when a bad record/line is encountered.

The default is to stop whenever unparsable lines are encountered and
this does not change.

If you add the following line to your yaml config, the parser will skip
unparsable lines so that it can continue processing.

     `stop_on_invalid_record: false`

This patch also imports access to the Exec objects Logger and will emit
log messages whenever it ignores log lines.